### PR TITLE
Fix compatibility with newer Python and OpenVPN versions

### DIFF
--- a/config.py
+++ b/config.py
@@ -170,7 +170,7 @@ def get_input(s, option):
 class Setting:
     def __init__(self, path):
         self.path = path
-        self.parser = configparser.SafeConfigParser()
+        self.parser = configparser.ConfigParser()
 
         self.proxy = OrderedDict([('use_proxy', 'no'), ('address', ''),
                                   ('port', ''),

--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@
 __author__ = "duc_tin"
 __copyright__ = "Copyright 2015+, duc_tin"
 __license__ = "GPLv2"
-__version__ = "1.25"
+__version__ = "1.26"
 __maintainer__ = "duc_tin"
 __email__ = "nguyenbaduc.tin@gmail.com"
 

--- a/ui_elements.py
+++ b/ui_elements.py
@@ -292,7 +292,7 @@ class AddPopUp(urwid.PopUpLauncher):
     signals = ['done']
 
     def __init__(self, target_widget, popup, value, trigger, size):
-        self.__super.__init__(target_widget)
+        super().__init__(target_widget)
         self.popup = popup(key=trigger, value=value)
         self.trigger = trigger
         self.size = size

--- a/ui_elements.py
+++ b/ui_elements.py
@@ -3,7 +3,7 @@
 __author__ = "duc_tin"
 __copyright__ = "Copyright 2015+, duc_tin"
 __license__ = "GPLv2"
-__version__ = "1.25"
+__version__ = "1.26"
 __maintainer__ = "duc_tin"
 __email__ = "nguyenbaduc.tin@gmail.com"
 
@@ -88,7 +88,7 @@ class PopUpSortBy(urwid.WidgetWrap):
 
         self.pile = urwid.Pile([ping, speed, uptime, score], focus_item=default[self.chosen])
         fill = urwid.LineBox(urwid.Filler(self.pile))
-        self.__super.__init__(urwid.AttrWrap(fill, 'popbg'))
+        super().__init__(urwid.AttrWrap(fill, 'popbg'))
 
     def item_callback(self, Button, data=None):
         self.chosen = self.pile.focus.label
@@ -117,7 +117,7 @@ class PopUpCountry(urwid.WidgetWrap):
 
         self.pile = urwid.Pile([info]+filter_)
         fill = urwid.LineBox(urwid.Filler(self.pile))
-        self.__super.__init__(urwid.AttrWrap(fill, 'popbg'))
+        super().__init__(urwid.AttrWrap(fill, 'popbg'))
 
         self.chosen = value
 
@@ -199,7 +199,7 @@ class PopUpProxy(urwid.WidgetWrap):
 
         self.pile = urwid.Pile(widgets)
         fill = urwid.LineBox(urwid.Filler(self.pile))
-        self.__super.__init__(urwid.AttrWrap(fill, 'popbg'))
+        super().__init__(urwid.AttrWrap(fill, 'popbg'))
 
         self.chosen = value
 
@@ -265,7 +265,7 @@ class PopUpDNS(urwid.WidgetWrap):
 
         self.pile = urwid.Pile(widgets)
         fill = urwid.LineBox(urwid.Filler(self.pile))
-        self.__super.__init__(urwid.AttrWrap(fill, 'popbg'))
+        super().__init__(urwid.AttrWrap(fill, 'popbg'))
 
         self.chosen = value
 
@@ -299,7 +299,7 @@ class AddPopUp(urwid.PopUpLauncher):
         self.result = value
 
     def create_pop_up(self):
-        # this method must be exist due to its blank content in original class
+        # this method must exist due to its blank content in original class
         urwid.connect_signal(self.popup, 'close', self.close_pop)
         return self.popup
 

--- a/vpnproxy_cli.py
+++ b/vpnproxy_cli.py
@@ -291,7 +291,7 @@ def vpn_manager(ovpn):
     """
     global dns, verbose, dropped_time
 
-    command = ['openvpn', '--config', ovpn]
+    command = ['openvpn', '--data-ciphers', 'AES-256-GCM:AES-128-GCM:AES-128-CBC:CHACHA20-POLY1305', '--config', ovpn]
     p = Popen(command, stdout=PIPE, stdin=PIPE, universal_newlines=True)
     try:
         while p.poll() is None:

--- a/vpnproxy_cli.py
+++ b/vpnproxy_cli.py
@@ -3,7 +3,7 @@
 __author__ = "duc_tin"
 __copyright__ = "Copyright 2015+, duc_tin"
 __license__ = "GPLv2"
-__version__ = "1.36"
+__version__ = "1.37"
 __maintainer__ = "duc_tin"
 __email__ = "nguyenbaduc.tin@gmail.com"
 

--- a/vpnproxy_tui.py
+++ b/vpnproxy_tui.py
@@ -3,7 +3,7 @@
 __author__ = "duc_tin"
 __copyright__ = "Copyright 2015+, duc_tin"
 __license__ = "GPLv2"
-__version__ = "1.5"
+__version__ = "1.6"
 __maintainer__ = "duc_tin"
 __email__ = "nguyenbaduc.tin@gmail.com"
 

--- a/vpnproxy_tui.py
+++ b/vpnproxy_tui.py
@@ -56,7 +56,7 @@ class Server:
         self.logPolicy = data[11]
         self.config_data = base64.b64decode(data[-1]).decode()
         self.proto = 'tcp' if '\r\nproto tcp\r\n' in self.config_data else 'udp'
-        port = re.findall('remote .+ \d+', self.config_data)
+        port = re.findall(r'remote .+ \d+', self.config_data)
         if not port:
             self.port = '0'
         else:
@@ -490,7 +490,7 @@ class Connection:
         vpn_file.close()
 
         ovpn = vpn_file.name
-        command = ['openvpn', '--config', ovpn]
+        command = ['openvpn', '--data-ciphers', 'AES-256-GCM:AES-128-GCM:AES-128-CBC:CHACHA20-POLY1305', '--config', ovpn]
         p = Popen(command, stdout=PIPE, stderr=PIPE, bufsize=1, close_fds=ON_POSIX, universal_newlines=True)
         q = Queue()
         t = Thread(target=self.vpn_output, args=(p.stdout, q))
@@ -510,7 +510,7 @@ class Connection:
 
         # make sure openvpn did close its device
         tuntap = Popen(['ip', 'tuntap'], stdout=PIPE, universal_newlines=True).communicate()[0]
-        devices = re.findall('tun\d+', tuntap)
+        devices = re.findall(r'tun\d+', tuntap)
         for dev in devices:
             call(('ip link delete ' + dev).split())
 


### PR DESCRIPTION
- Newer Python versions use `ConfigParser` instead of `SafeConfigParser`
- OpenVPN configs from VPNGate use the `AES-128-CBC` cipher, which is rejected by newer OpenVPN versions unless it's added to the allowed cipher list (`--data-ciphers`)